### PR TITLE
Exclude branch names that may match multiple branches

### DIFF
--- a/src/common.ts
+++ b/src/common.ts
@@ -61,3 +61,8 @@ export async function getRemoteGitCommit(
     return null;
   }
 }
+
+/** This pattern filters out a subset of illegal branch names. It's not perfect,
+but it should eliminate all uses of patterns that may match multiple branch
+names. */
+export const branchNamePattern = "^[^*?[]+$" as const;

--- a/src/docker.test.ts
+++ b/src/docker.test.ts
@@ -66,7 +66,7 @@ describe("Brief test directly for a running Docker container", () => {
       expect(await response.text()).toBe("");
     });
 
-    test("Return 400 with valid payload but invalid git repository", async () => {
+    test("Return 403 with valid payload but invalid git repository", async () => {
       const repository = "git://localhost/non-existing" as const;
       const branch = "trunk" as const;
       const response = await fetch(`${instanceAddress}/${newFirstPathComp}`, {
@@ -127,6 +127,14 @@ describe("Brief test directly for a running Docker container", () => {
         // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
         last_commit_retrieval_time: expect.any(Number),
       });
+    });
+
+    test("Return 400 with invalid path components", async () => {
+      const response = await fetch(
+        `${instanceAddress}/list-commits/repo/mas*ter?num_of_commits=1`,
+      );
+
+      expect(response.status).toBe(400);
     });
   });
 });

--- a/src/route_list_commits.ts
+++ b/src/route_list_commits.ts
@@ -17,6 +17,7 @@
  */
 
 import { FastifyPluginAsyncJsonSchemaToTs } from "@fastify/type-provider-json-schema-to-ts";
+import { branchNamePattern } from "./common.js";
 
 interface QueryStringSchemaInterface {
   num_of_commits: number;
@@ -47,7 +48,7 @@ const plugin: FastifyPluginAsyncJsonSchemaToTs = async function (fastify, _) {
           type: "object",
           properties: {
             repository: { type: "string" },
-            branch: { type: "string" },
+            branch: { type: "string", pattern: branchNamePattern },
           },
           required: ["repository", "branch"],
         },

--- a/src/route_new.ts
+++ b/src/route_new.ts
@@ -16,8 +16,8 @@
  * along with this program.  If not, see <https://www.gnu.org/licenses/>.
  */
 
+import { branchNamePattern, getRemoteGitCommit } from "./common.js";
 import { FastifyPluginAsyncJsonSchemaToTs } from "@fastify/type-provider-json-schema-to-ts";
-import { getRemoteGitCommit } from "./common.js";
 
 // eslint-disable-next-line @typescript-eslint/require-await
 const plugin: FastifyPluginAsyncJsonSchemaToTs = async function (fastify, _) {
@@ -29,7 +29,10 @@ const plugin: FastifyPluginAsyncJsonSchemaToTs = async function (fastify, _) {
           type: "object",
           properties: {
             repository: { type: "string" },
-            branch: { type: "string" },
+            branch: {
+              type: "string",
+              pattern: branchNamePattern,
+            },
           },
           required: ["repository", "branch"],
         },


### PR DESCRIPTION
Disallow *, [, ? in branch names as they are special characters in pattern matching in `git ls-remote`, and they are not allowed in a branch name.