### PR TITLE
Harden getRemoteGitCommit a bit to prevent accidental wildcard character

### DIFF
--- a/packages/api-server/.gitignore
+++ b/packages/api-server/.gitignore
@@ -1,0 +1,6 @@
+dist
+/docs
+node_modules
+*.tsbuildinfo
+coverage
+/.env

--- a/packages/common/.gitignore
+++ b/packages/common/.gitignore
@@ -1,0 +1,6 @@
+dist
+/docs
+node_modules
+*.tsbuildinfo
+coverage
+/.env

--- a/packages/common/src/common.ts
+++ b/packages/common/src/common.ts
@@ -28,11 +28,23 @@ const git_executable_path = process.env.GIT_EXECUTABLE_PATH ?? "/usr/bin/git";
 /** git command timeout in milliseconds. */
 const git_command_timeout = parseInt(process.env.GIT_COMMAND_TIMEOUT ?? "2000");
 
-/** Get remote git commit hash of a given branch of a given URL. */
+/** Get remote git commit hash of a given branch of a given URL.
+ *
+ * @param url - URL of the git repository.
+ * @param branch - Branch name. It must not contain wildcard characters, *, [,
+ * ?.
+ */
 export async function getRemoteGitCommit(
   url: string,
   branch: string,
 ): Promise<string | null> {
+  /* v8 ignore start */
+  if (branch.includes("?") || branch.includes("*") || branch.includes("[")) {
+    // branch contains wildcard characters
+    throw new Error(`Unexpected wildcard character in branch name: ${branch}`);
+  }
+  /* v8 ignore end */
+
   try {
     // TODO: refuse http
     const { stdout } = await execFile(

--- a/packages/updater/.gitignore
+++ b/packages/updater/.gitignore
@@ -1,0 +1,6 @@
+dist
+/docs
+node_modules
+*.tsbuildinfo
+coverage
+/.env


### PR DESCRIPTION
The restraint in /new should prevent this. Extra check to harden it.