### PR TITLE
db: Use milliseconds instead of seconds precision for retrieval times

### DIFF
--- a/packages/api-server/src/index.test.ts
+++ b/packages/api-server/src/index.test.ts
@@ -189,9 +189,8 @@ describe("/list-commits", () => {
     const repository = "git://localhost/repos/single-branch" as const;
     const branch = "trunk" as const;
     const fakeSystemTime = 1737501641134 as const;
-    // The app stores rounded down to seconds. It appears to be a round up of
-    // fakeSystemTime because the mock timer advances the time by 1 second.
-    const expectedRetrievalTime = 1737501642000 as const;
+    // The mock timer advances the time by 1 second.
+    const expectedRetrievalTime = fakeSystemTime + 1000;
     vi.useFakeTimers({
       now: fakeSystemTime,
       shouldAdvanceTime: true,

--- a/packages/updater/src/index.test.ts
+++ b/packages/updater/src/index.test.ts
@@ -104,11 +104,7 @@ describe("Test updating commit", () => {
     const now = new Date().getTime();
     const yesterday = new Date();
     const dayOffset = 24 * 60 * 60 * 1000 + 1;
-    yesterday.setTime(
-      // Use 1000 of milliseconds because the last commit retrieval time is
-      // stored truncated to seconds.
-      Math.floor((yesterday.getTime() - dayOffset) / 1000) * 1000,
-    );
+    yesterday.setTime(yesterday.getTime() - dayOffset);
     await updateSingleBranchRepoLastCommitRetrievalTime(yesterday);
 
     await updateCommits(1);
@@ -141,8 +137,7 @@ describe("Test updating commit", () => {
     }
     expect(
       commitsAfterUpdate.last_commit_retrieval_time,
-      // Leave 1s for time truncation in db.
-    ).toBeGreaterThanOrEqual(now - 1000);
+    ).toBeGreaterThanOrEqual(now);
     expect(commitsAfterUpdate).toHaveProperty(
       "commits",
       commitsBeforeUpdate.commits,

--- a/prisma/migrations/20250204080904_init/migration.sql
+++ b/prisma/migrations/20250204080904_init/migration.sql
@@ -3,7 +3,7 @@ CREATE TABLE "branches" (
     "id" SERIAL NOT NULL,
     "repository" TEXT NOT NULL,
     "branch" TEXT NOT NULL,
-    "last_commit_retrieval_time" TIMESTAMP(0) NOT NULL,
+    "last_commit_retrieval_time" TIMESTAMP(3) NOT NULL,
 
     CONSTRAINT "branches_pkey" PRIMARY KEY ("id")
 );
@@ -11,7 +11,7 @@ CREATE TABLE "branches" (
 -- CreateTable
 CREATE TABLE "commits" (
     "branch_id" INTEGER NOT NULL,
-    "retrieval_time" TIMESTAMP(0) NOT NULL,
+    "retrieval_time" TIMESTAMP(3) NOT NULL,
     "commit_hash" TEXT NOT NULL,
 
     CONSTRAINT "commits_pkey" PRIMARY KEY ("branch_id","retrieval_time")

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -11,7 +11,7 @@ model branches {
   id                         Int       @id @default(autoincrement())
   repository                 String
   branch                     String
-  last_commit_retrieval_time DateTime  @db.Timestamp(0)
+  last_commit_retrieval_time DateTime  @db.Timestamp(3)
   commits                    commits[]
 
   @@unique([repository, branch])
@@ -20,7 +20,7 @@ model branches {
 
 model commits {
   branch_id      Int
-  retrieval_time DateTime @db.Timestamp(0)
+  retrieval_time DateTime @db.Timestamp(3)
   commit_hash    String
   branches       branches @relation(fields: [branch_id], references: [id], onDelete: NoAction, onUpdate: NoAction, map: "fk_branches")
 


### PR DESCRIPTION
They are indexed and reducing clashes reduces chances of lock contention.